### PR TITLE
Add Python 3.6 and drop Python 3.3

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,11 @@
+[run]
+source = zope.copypastemove
+
+[report]
+precision = 2
+exclude_lines =
+    pragma: no cover
+    if __name__ == '__main__':
+    raise NotImplementedError
+    self.fail
+    raise AssertionError

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ develop-eggs/
 docs/
 eggs/
 parts/
+.coverage
+htmlcov/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,19 @@ language: python
 sudo: false
 python:
     - 2.7
-    - 3.3
     - 3.4
     - 3.5
+    - 3.6
     - pypy
+    - pypy3.5-5.8.0
 install:
-    - pip install .
+    - pip install -U pip setuptools
+    - pip install -U coverage coveralls
+    - pip install -U -e .[test]
 script:
-    - python setup.py test -q
+    - coverage run -m zope.testrunner --test-path=src
+after_success:
+    - coveralls
 notifications:
     email: false
+cache: pip

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,16 +1,17 @@
-Changes
-=======
+=========
+ Changes
+=========
 
 4.1.0 (unreleased)
-------------------
+==================
 
-- Add support for Python 3.5.
+- Add support for Python 3.5 and 3.6.
 
-- Drop support for Python 2.6.
+- Drop support for Python 2.6 and 3.3.
 
 
 4.0.0 (2014-12-24)
-------------------
+==================
 
 - Add support for PyPy.
 
@@ -20,7 +21,7 @@ Changes
 
 
 4.0.0a1 (2013-02-24)
---------------------
+====================
 
 - Add support for Python 3.3.
 
@@ -37,7 +38,7 @@ Changes
 
 
 3.8.0 (2010-09-14)
-------------------
+==================
 
 - Add a test that makes sure that dublin core meta data of folder contents
   get updated when the folder gets copied. (Requires `zope.dublincore` 3.8
@@ -45,7 +46,7 @@ Changes
 
 
 3.7.0 (2010-09-14)
-------------------
+==================
 
 - Honor the name given by the ``IObjectMover`` in
   ``OrderedContainerItemRenamer.renameItem``. It now returns the new of the
@@ -62,21 +63,21 @@ Changes
 - Move ``zope.copypastemove``-related tests from ``zope.container`` here.
 
 3.6.0 (2009-12-16)
-------------------
+==================
 
 - Favor ``zope.principalannotation`` over its ``zope.app`` variant.
 
 - Avoid ``zope.app.component`` and testing dependencies.
 
 3.5.2 (2009-08-15)
-------------------
+==================
 
 - Fix documentation for the ``IObjectCopier.copyTo`` method.
 
 - Add a missing dependency on ``zope.app.component``.
 
 3.5.1 (2009-02-09)
-------------------
+==================
 
 - Use the new ``zope.copy`` package for ObjectCopier to provide pluggable
   copying mechanism that is not dependent on ``zope.location`` hardly.
@@ -87,22 +88,22 @@ Changes
   place is preferred.
 
 3.5.0 (2009-01-31)
-------------------
+==================
 
 - Use ``zope.container`` instead of ``zope.app.container``.
 
 3.4.1 (2009-01-26)
-------------------
+==================
 
 - Move the test dependencies to a ``test`` extra requirement.
 
 3.4.0 (2007-09-28)
-------------------
+==================
 
 - No further changes since 3.4.0a1.
 
 3.4.0a1 (2007-04-22)
---------------------
+====================
 
 - Initial release as a separate project, corresponds to
   ``zope.copypastemove`` from Zope 3.4.0a1

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,9 @@ include *.txt
 include *.py
 include buildout.cfg
 include tox.ini
+include .travis.yml
+include .coveragerc
+
 
 recursive-include src *
 

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,20 @@
-``zope.copypastemove``
-======================
+========================
+ ``zope.copypastemove``
+========================
+
+.. image:: https://img.shields.io/pypi/v/zope.copypastemove.svg
+        :target: https://pypi.python.org/pypi/zope.copypastemove/
+        :alt: Latest release
+
+.. image:: https://img.shields.io/pypi/pyversions/zope.copypastemove.svg
+        :target: https://pypi.org/project/zope.copypastemove/
+        :alt: Supported Python versions
 
 .. image:: https://travis-ci.org/zopefoundation/zope.copypastemove.png?branch=master
         :target: https://travis-ci.org/zopefoundation/zope.copypastemove
+
+.. image:: https://coveralls.io/repos/github/zopefoundation/zope.copypastemove/badge.svg?branch=master
+        :target: https://coveralls.io/github/zopefoundation/zope.copypastemove?branch=master
 
 This package provides Copy, Paste and Move support for content
 components in Zope.  In particular, it defines the following

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ def read(*rnames):
         return f.read()
 
 def alltests():
-    import os
     import sys
     import unittest
     # use the zope.testrunner machinery to find all the
@@ -40,66 +39,67 @@ def alltests():
 
 long_description = (read('README.rst') + '\n\n' + read('CHANGES.rst'))
 
+ZCML_REQUIRES = [
+    'zope.component[zcml]',
+    'zope.configuration',
+    'zope.security[zcml]',
+]
+
+TESTS_REQUIRE = ZCML_REQUIRES + [
+    'zope.dublincore >= 3.8',
+    'zope.principalannotation',
+    'zope.testing',
+    'zope.testrunner',
+    'zope.traversing',
+]
+
 setup(name='zope.copypastemove',
       version='4.1.0.dev0',
-      url='http://pypi.python.org/pypi/zope.copypastemove',
+      url='http://github.com/zopefoundation/zope.copypastemove',
       license='ZPL 2.1',
       author='Zope Foundation and Contributors',
       author_email='zope-dev@zope.org',
       description="Copy, Paste and Move support for content components.",
       long_description=long_description,
       classifiers=[
-        'Environment :: Web Environment',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: Zope Public License',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: Implementation :: CPython',
-        'Programming Language :: Python :: Implementation :: PyPy',
-        'Natural Language :: English',
-        'Operating System :: OS Independent',
-        'Topic :: Internet :: WWW/HTTP',
-        'Framework :: Zope3',
-        ],
-
+          'Environment :: Web Environment',
+          'Intended Audience :: Developers',
+          'License :: OSI Approved :: Zope Public License',
+          'Programming Language :: Python',
+          'Programming Language :: Python :: 2',
+          'Programming Language :: Python :: 2.7',
+          'Programming Language :: Python :: 3',
+          'Programming Language :: Python :: 3.4',
+          'Programming Language :: Python :: 3.5',
+          'Programming Language :: Python :: 3.6',
+          'Programming Language :: Python :: Implementation :: CPython',
+          'Programming Language :: Python :: Implementation :: PyPy',
+          'Natural Language :: English',
+          'Operating System :: OS Independent',
+          'Topic :: Internet :: WWW/HTTP',
+          'Framework :: Zope3',
+      ],
       packages=find_packages('src'),
-      package_dir = {'': 'src'},
+      package_dir={'': 'src'},
       namespace_packages=['zope',],
-      extras_require=dict(
-          test=['zope.principalannotation',
-                'zope.testing',
-                'zope.traversing',
-                'zope.dublincore >= 3.8',
-                ],
-          zcml=[
-            'zope.component[zcml]',
-            'zope.configuration',
-            'zope.security[zcml]',
-            ]),
-      install_requires=['setuptools',
-                        'zope.annotation',
-                        'zope.component',
-                        'zope.container',
-                        'zope.copy',
-                        'zope.event',
-                        'zope.exceptions',
-                        'zope.interface',
-                        'zope.lifecycleevent',
-                        'zope.location',
-                        ],
-      tests_require = [
-          'zope.dublincore',
-          'zope.principalannotation',
-          'zope.testing',
-          'zope.testrunner',
-          'zope.traversing',
-          ],
-      test_suite = '__main__.alltests',
-      include_package_data = True,
-      zip_safe = False,
-      )
+      extras_require={
+          'test': TESTS_REQUIRE,
+          'zcml': ZCML_REQUIRES,
+      },
+      install_requires=[
+          'setuptools',
+          'zope.annotation',
+          'zope.component',
+          'zope.container',
+          'zope.copy',
+          'zope.event',
+          'zope.exceptions',
+          'zope.interface',
+          'zope.lifecycleevent',
+          'zope.location',
+      ],
+      tests_require=TESTS_REQUIRE,
+      test_suite='__main__.alltests',
+      include_package_data=True,
+      zip_safe=False,
+)

--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__('pkg_resources').declare_namespace(__name__) # pragma: no cover

--- a/src/zope/copypastemove/__init__.py
+++ b/src/zope/copypastemove/__init__.py
@@ -23,7 +23,6 @@ from zope.copy import copy
 from zope.event import notify
 from zope.location.interfaces import ISublocations
 from zope.annotation.interfaces import IAnnotations
-from zope.annotation.interfaces import IAnnotations
 from zope.lifecycleevent import ObjectCopiedEvent
 
 from zope.copypastemove.interfaces import IObjectMover
@@ -376,7 +375,6 @@ class ObjectCopier(object):
         an `IObjectCopied` event is published.
         """
         obj = self.context
-        container = obj.__parent__
 
         orig_name = obj.__name__
         if new_name is None:
@@ -589,9 +587,9 @@ class ExampleContainer(SampleContainer):
     # Sample container used for examples in doc stringss in this module
 
     def chooseName(self, name, ob):
-       while name in self:
-          name += '_'
-       return name
+        while name in self:
+            name += '_'
+        return name
 
 
 def dispatchToSublocations(object, event):
@@ -665,5 +663,4 @@ def dispatchToSublocations(object, event):
     subs = ISublocations(object, None)
     if subs is not None:
         for sub in subs.sublocations():
-            for ignored in zope.component.subscribers((sub, event), None):
-                pass # They do work in the adapter fetch
+            zope.component.handle(sub, event)

--- a/src/zope/copypastemove/tests/test_clipboard.py
+++ b/src/zope/copypastemove/tests/test_clipboard.py
@@ -82,10 +82,8 @@ class PrincipalClipboardTest(PlacelessSetup, unittest.TestCase):
         self.assertEqual(clipboard.getContents(), ())
 
 def test_suite():
-    return unittest.TestSuite((
-        unittest.makeSuite(PrincipalClipboardTest),
-        ))
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)
 
-if __name__=='__main__':
+
+if __name__ == '__main__':
     unittest.main(defaultTest='test_suite')
-

--- a/src/zope/copypastemove/tests/test_configure.py
+++ b/src/zope/copypastemove/tests/test_configure.py
@@ -21,11 +21,8 @@ import zope.configuration.xmlconfig
 class ZCMLTest(unittest.TestCase):
 
     def test_configure_zcml_should_be_loadable(self):
-        try:
-            zope.configuration.xmlconfig.XMLConfig(
-                'configure.zcml', zope.copypastemove)()
-        except Exception as e:
-            self.fail(e)
+        zope.configuration.xmlconfig.XMLConfig(
+            'configure.zcml', zope.copypastemove)()
 
     def test_configure_should_register_n_components(self):
         gsm = zope.component.getGlobalSiteManager()

--- a/tox.ini
+++ b/tox.ini
@@ -1,23 +1,20 @@
 [tox]
 envlist =
-    py27,py33,py34,py35,pypy
+   py27,py34,py35,py36,pypy,pypy3,coverage
 
 [testenv]
 commands =
-    python setup.py -q test -q
+    zope-testrunner --test-path=src []
 deps =
-    ZODB
-    zope.annotation
-    zope.component
-    zope.container
-    zope.copy
-    zope.dublincore
-    zope.event
-    zope.exceptions
-    zope.interface
-    zope.lifecycleevent
-    zope.location
-    zope.principalannotation
-    zope.testing
-    zope.testrunner
-    zope.traversing
+    .[test]
+
+[testenv:coverage]
+usedevelop = true
+basepython =
+    python2.7
+commands =
+    coverage run -m zope.testrunner --test-path=src
+    coverage report --fail-under=100
+deps =
+    {[testenv]deps}
+    coverage


### PR DESCRIPTION
- Badges
- Enable coverage and coveralls
  - 100% coverage
- DRY with dependencies.
- Test compatibility with new zope.container that fixes
  OrderedContainer to store unicode keys.
  - Convert failing doctest into real test.